### PR TITLE
signTx compressPubKey param defaults to true

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -343,7 +343,7 @@ function getScriptSignature(privKey, signingTx, hashcode) {
  * return {String} signed transaction
  */
 function signTx(_txObj, i, privKey) {
-  var compressPubKey = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : false;
+  var compressPubKey = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : true;
   var hashcode = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : zconstants.SIGHASH_ALL;
 
   // Make a copy

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -401,7 +401,7 @@ function signTx (
   _txObj: TXOBJ,
   i: number,
   privKey: string,
-  compressPubKey: boolean = false,
+  compressPubKey: boolean = true,
   hashcode: number = zconstants.SIGHASH_ALL
 ): TXOBJ {
   // Make a copy


### PR DESCRIPTION
Currently if `compressPubKey == false` in `signTx`, we can't push transaction because of [this issue](https://github.com/ZencashOfficial/zencashjs/issues/12). I propose simple fix with `true` as default value