### PR TITLE
Update check-lib-sync.sh

### DIFF
--- a/scripts/check-lib-sync.sh
+++ b/scripts/check-lib-sync.sh
@@ -4,7 +4,10 @@ diff_in_dir() {
   TARGET_BRANCH=${TARGET_BRANCH:-master}
   DIFF=$(git diff --name-only origin/"$TARGET_BRANCH" "$1")
   for FILE in $DIFF; do
-    basename "$FILE"
+    # Ignore changes to src/types.js because it only has Flow type annotations and it does not compile to any vanilla Javascript
+    if [[ "$FILE" != "src/types.js" ]]; then
+      basename "$FILE"
+    fi
   done
 }
 


### PR DESCRIPTION
Update check-lib-sync.sh to ignore the `src/types.js` file in the diff.
It does not compile to any plain Javascript